### PR TITLE
Using regular expression (new in RSQLite) for src_sqlite() docdb_query()

### DIFF
--- a/R/src_sqlite.R
+++ b/R/src_sqlite.R
@@ -36,6 +36,20 @@ src_sqlite <- function(dbname = ":memory:",
          "install.packages('RSQLite') to install a current version.")
   }
   
+  # check if regular expressions are supported (RSQLite >= 2.1.2)
+  if ("try-error" %in% class(
+    try({
+      RSQLite::initRegExp(db = con)
+      DBI::dbExecute(
+        conn = con, 
+        statement = paste0('SELECT * FROM (VALUES ("Astring")) WHERE 1 REGEXP "[A-Z][a-z]+";'))
+      }, silent = TRUE)
+  )) {
+    attr(x = con, which = "regexp.extension") <- FALSE
+  } else {
+    attr(x = con, which = "regexp.extension") <- TRUE
+  }
+  
   # return standard nodbi structure
   structure(list(con = con, 
                  dbname = dbname, 

--- a/man/docdb_query.Rd
+++ b/man/docdb_query.Rd
@@ -88,6 +88,7 @@ src <- src_sqlite()
 docdb_create(src, "mtcars", mtcars)
 docdb_query(src, "mtcars", query = "{}", fields = '{"mpg":1, "cyl":1}')
 docdb_query(src, "mtcars", query = '{"gear": {"$lte": 4}}', fields = '{"gear": 1}')
-docdb_query(src, "mtcars", query = '{"_id": {"$regex": "0\%"}}', fields = '{"gear": 1}')
+# for RSQLite from 2.1.2 using PCRE regular expressions
+docdb_query(src, "mtcars", query = '{"_id": {"$regex": "^.+0.*$"}}', fields = '{"gear": 1}')
 }
 }

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -84,17 +84,20 @@ test_that("query in sqlite works", {
   invisible(docdb_create(con, "mtcars", mtcars))
   
   expect_is(
-      docdb_query(con, "mtcars", query = "{}", fields = '{"mpg":1, "cyl": 1}'),
+    docdb_query(con, "mtcars", query = "{}", fields = '{"mpg":1, "cyl": 1}'),
     "data.frame")
-
+  
+  # depending on availability of regular expression operator
   expect_length(
-      docdb_query(con, "mtcars", 
-                  query = '{"gear" : 4, "cyl": {"$lte": 8}, "_row": {"$regex": "M%"} }', 
-                  fields = '{"mpg":1, "cyl": 1, "_row": 1}')[["_id"]],
+    docdb_query(con, "mtcars", 
+                query = paste0('{"gear" : 4, "cyl": {"$lte": 8}, "_row": {"$regex": "', 
+                               ifelse(attr(x = con$con, which = "regexp.extension"), 
+                                      '^M[a-z].*', 'M%'), '"} }'), 
+                fields = '{"mpg":1, "cyl": 1, "_row": 1}')[["_id"]],
     6L)
-
+  
   invisible(docdb_create(con, "mtcars", value = data.frame(contacts, stringsAsFactors = FALSE)))
-
+  
   expect_equal(
     docdb_query(con, "mtcars", 
                 fields = '{"age": 1, "name": 1}', 

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -3,10 +3,12 @@ test_that("Source", {
   skip_on_cran()
   
   skip_if_no_sqlite()
-  src <- src_sqlite()
-  expect_is(src, "docdb_src")
-  expect_is(src, "src_sqlite")
-  expect_is(src$con, "SQLiteConnection")
+  con <- src_sqlite()
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
+  
+  expect_is(con, "docdb_src")
+  expect_is(con, "src_sqlite")
+  expect_is(con$con, "SQLiteConnection")
 })
 
 context("sqlitedb: create")
@@ -15,6 +17,8 @@ test_that("db into sqlite", {
   
   skip_if_no_sqlite()
   con <- src_sqlite()
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
+  
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "iris"), error = function(e) e))
   
@@ -27,10 +31,10 @@ test_that("db into sqlite", {
   d2 <- d2[, -1]
   
   expect_equal(d2, iris)
-
+  
   # check if timing acceptable  
   docdb_create(con, "diamonds", diamonds)
-
+  
 })
 
 context("sqlitedb: delete")
@@ -39,6 +43,8 @@ test_that("delete in sqlite works", {
   
   skip_if_no_sqlite()
   con <- src_sqlite()
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
+  
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "iris"), error = function(e) e))
   
@@ -53,6 +59,8 @@ test_that("exists in sqlite works", {
   
   skip_if_no_sqlite()
   con <- src_sqlite()
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
+  
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "iris"), error = function(e) e))
   
@@ -68,6 +76,8 @@ test_that("query in sqlite works", {
   
   skip_if_no_sqlite()
   con <- src_sqlite()
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
+  
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "mtcars"), error = function(e) e))
   
@@ -111,6 +121,8 @@ test_that("update in sqlite works", {
   
   skip_if_no_sqlite()
   con <- src_sqlite()
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
+  
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "mtcars"), error = function(e) e))
   
@@ -149,7 +161,7 @@ test_that("update in sqlite works", {
   
   expect_equal(docdb_update(con, "mtcars", value), 1L)
   expect_equal(docdb_query(con, "mtcars", query = "{}", fields = '{"a": 1}')[["a"]], 123)
-
+  
   # multiple - upsert
   value <- data.frame("_id" = c("3", "5"), 
                       "gear" = c(99, 66), 


### PR DESCRIPTION
Hi, this is a PR for an important improvement of the `docdb_query()` method when used with `src_sqlite()` databases, by using the regular expression operator that is since very recently available from `RSQLite` version 2.1.2. onwards. Thank you for considering! 