### PR TITLE
fix for docdb_update() used with sqlite: to quote strings

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -191,7 +191,11 @@ docdb_update.src_sqlite <- function(src, key, value, ...) {
                               WHERE key = '%s'
                                 AND value = %s;",
                         key, key,
-                        vn[1], value[i , 1]))
+                        vn[1], 
+                        ifelse(class(value[i, 1]) == "character", 
+                               paste0("'", value[i , 1], "'"),
+                               value[i , 1])
+                      ))
     })
     
     # replace first column with _id
@@ -200,7 +204,8 @@ docdb_update.src_sqlite <- function(src, key, value, ...) {
       tmp <- data.frame(idsaffected[i], 
                         value[i, -1], 
                         stringsAsFactors = FALSE,
-                        check.rows = FALSE)
+                        check.rows = FALSE,
+                        row.names = NULL)
       
       names(tmp) <- c("_id", vn[-1])
       

--- a/R/update.R
+++ b/R/update.R
@@ -220,30 +220,39 @@ docdb_update.src_sqlite <- function(src, key, value, ...) {
   
   # iterate over columns
   ncoliterated <- sapply(seq(2, ncol(value)), function(i) {
-    
+
     # identifier _id is table index
-    nrowaffected <- 
+    nrowaffected <-
       sapply(seq_len(nrow(value)), function(ii) {
-        
-        statement <- sprintf(
-          "UPDATE %s
-         SET json = 
-          (SELECT json_set( 
-                  json( %s.json ), '$.%s', json ( %s ))
-           FROM %s 
-           WHERE _id = '%s')
-         WHERE _id = '%s';", 
-          key, 
-          key, vn[i], valueEscape(value[ii, i, drop = TRUE]), 
-          key,
-          value[ii, 1],
-          value[ii, 1]
-        )
-        
-        # execute
-        DBI::dbExecute(
-          conn = src$con, 
-          statement = statement)
+
+        # check if current cell has a value
+        if (!is.na(value[ii, i, drop = TRUE])) {
+          
+          statement <- sprintf(
+            "UPDATE %s
+             SET json =
+              (SELECT json_set(
+                      json( %s.json ), '$.%s', json ( %s ))
+               FROM %s
+               WHERE _id = '%s')
+             WHERE _id = '%s';",
+            key,
+            key, vn[i], valueEscape(value[ii, i, drop = TRUE]),
+            key,
+            value[ii, 1],
+            value[ii, 1]
+          )
+          
+          # execute
+          DBI::dbExecute(
+            conn = src$con,
+            statement = statement)
+          
+        } else {
+          
+          # no record changed
+          0
+        }
         
       }) # nrowaffected
     nrowaffected

--- a/R/update.R
+++ b/R/update.R
@@ -192,7 +192,7 @@ docdb_update.src_sqlite <- function(src, key, value, ...) {
                                 AND value = %s;",
                         key, key,
                         vn[1], 
-                        ifelse(class(value[i, 1]) == "character", 
+                        ifelse(inherits(value[i, 1], "character"), 
                                paste0("'", value[i , 1], "'"),
                                value[i , 1])
                       ))

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -178,12 +178,18 @@ test_that("update in sqlite works", {
   expect_equal(tmp[["cyl"]][tmp[["_id"]] == "5"], 77)
   
   ## test other paths than _id
-  value <- data.frame("gear" = c("4", "5"),
-                      "a" = c(8, 7),
+  value <- data.frame("gear" = c(3, 4, 5),
+                      "a" =    c(8, 7, NA),
+                      "b" =    c("b1", NA, "b2"),
                       stringsAsFactors = FALSE)
   
-  expect_equal(docdb_update(con, "mtcars", value), 15L)
-  tmp <- docdb_query(con, "mtcars", query = "{}", fields = '{"gear": 1, "a": 1}')
-  expect_true(all(tmp[["a"]][tmp[["gear"]] == 4] == 8))
+  # table(docdb_get(con, "mtcars")[["gear"]])
+  #  3  4  5  9 66 99 
+  # 14 10  5  1  1  1 
+  # -> 14 + 14 + 10 + 5 = 43
+  expect_equal(docdb_update(con, "mtcars", value), 43L)
+  tmp <- docdb_get(con, "mtcars")
+  expect_true(all(tmp[["a"]][tmp[["gear"]] == 3] == 8))
+  expect_true(all(is.na(tmp[["a"]][tmp[["gear"]] == 5])))
   
 })


### PR DESCRIPTION
Hi, this is a fix that adds quotations when strings are used to search for keys other than _id to identify rows in which another key(s) should be updated. If more than one key to be updated, avoid warning by not creating row names from update values. 