### PR TITLE
Add handling json directly in docdb_update() for src_sqlite()

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -271,7 +271,7 @@ valueEscape <- function(x) {
   switch(class(x),
          
          # - character: '"stringvalue"'
-         "character" = ifelse(test = grepl("^[{].*[}]$", x), 
+         "character" = ifelse(test = grepl("^[{].*[}]$", trimws(x)), 
                               yes = paste0('\'', x, '\''), 
                               no = paste0('\'\"', x, '\"\'')),
          # - list e.g.: '{"a": "something", "b": 2}'

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -116,6 +116,12 @@ test_that("query in sqlite works", {
                 query = '{"_id": "5cd6785335b63cb19dfa8347"}')[["name"]],
     "Williamson French")
   
+  expect_equal(
+    docdb_query(con, "mtcars", 
+                fields = '{"age": 1, "friends[1].id": 1}', 
+                query = '{"_id": "5cd6785335b63cb19dfa8347"}')[["age"]],
+    30L)
+  
 })
 
 context("sqlitedb: update")

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -198,4 +198,13 @@ test_that("update in sqlite works", {
   expect_true(all(tmp[["a"]][tmp[["gear"]] == 3] == 8))
   expect_true(all(is.na(tmp[["a"]][tmp[["gear"]] == 5])))
   
+  ## test updating with json string
+  value <- data.frame("carb" = 8L,
+                      "json" = '{"mpg": 123, "gear": 3}',
+                      stringsAsFactors = FALSE)
+  expect_equal((docdb_update(src = con, key = "mtcars", value = value)), 1L)
+  tmp <- docdb_get(con, "mtcars")
+  expect_true(all(tmp[["gear"]][tmp[["mpg"]] == 123L] == 3L))
+  expect_true(all(is.na(tmp[["carb"]][tmp[["mpg"]] == 123L])))
+  
 })

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -157,7 +157,7 @@ test_that("update in sqlite works", {
                       # to have _id as column name
                       check.names = FALSE) 
   
-  expect_equal((docdb_update(con, "mtcars", value)), 1L)
+  expect_equal(docdb_update(con, "mtcars", value), 1L)
   tmp <- docdb_query(con, "mtcars", query = "{}", fields = '{"gear": 1}')
   expect_equal(tmp[["gear"]][tmp[["_id"]] == "2"], 9)
   


### PR DESCRIPTION
Good day and here is a PR for extending a bit the update method to directly handle values that are already a json object (string in json format). Thank you for considering!  