### PR TITLE
Improved docdb_update() for src_sqlite()

### DIFF
--- a/man/docdb_update.Rd
+++ b/man/docdb_update.Rd
@@ -50,17 +50,21 @@ docdb_get(src, "mtcars")
 
 # SQLite
 src <- src_sqlite()
-docdb_create(src, "mtcars",
-             data.frame("_id" = seq_len(nrow(mtcars)),
-                        mtcars,
-                        stringsAsFactors = FALSE,
-                        check.names = FALSE))
-dfupd <- data.frame("cyl" = 4, "gear" = 99,
-                    stringsAsFactors = FALSE,
-                    check.names = FALSE)
+docdb_create(src, "mtcars", mtcars)
+dfupd <- data.frame("cyl" = c(4, 6),
+                    "gear" = c(88, 99),
+                    stringsAsFactors = FALSE)
 docdb_update(src, "mtcars", dfupd)
 docdb_query(src, "mtcars",
-            query = '{"gear": {"$gt": 10}}',
+            query = '{"gear": {"$gte": 88}}',
             fields = '{"gear": 1, "cyl": 1}')
+dfupd <- data.frame("cyl" = c(8, 6),
+                    "somejson" = c('{"gear": 77, "carb": 55}',
+                                   '{"gear": 66, "newvar": 55}'),
+                    stringsAsFactors = FALSE)
+docdb_update(src, "mtcars", dfupd)
+docdb_query(src, "mtcars",
+            query = '{"gear": {"$eq": 66}}',
+            fields = '{"gear": 1, "cyl": 1, "carb": 1, "newvar": 1}')
 }
 }

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -179,7 +179,7 @@ test_that("update in sqlite works", {
                       # to have _id as column name
                       check.names = FALSE) 
   
-  expect_equal(docdb_update(con, "mtcars", value), 4L)
+  expect_equal(docdb_update(con, "mtcars", value), 2L)
   tmp <- docdb_query(con, "mtcars", query = "{}", fields = '{"gear": 1, "cyl": 1}')
   expect_equal(tmp[["cyl"]][tmp[["_id"]] == "5"], 77)
   
@@ -189,22 +189,19 @@ test_that("update in sqlite works", {
                       "b" =    c("b1", NA, "b2"),
                       stringsAsFactors = FALSE)
   
-  # table(docdb_get(con, "mtcars")[["gear"]])
-  #  3  4  5  9 66 99 
-  # 14 10  5  1  1  1 
-  # -> 14 + 14 + 10 + 5 = 43
-  expect_equal(docdb_update(con, "mtcars", value), 43L)
+  expect_equal(docdb_update(con, "mtcars", value), 29L)
   tmp <- docdb_get(con, "mtcars")
   expect_true(all(tmp[["a"]][tmp[["gear"]] == 3] == 8))
   expect_true(all(is.na(tmp[["a"]][tmp[["gear"]] == 5])))
   
   ## test updating with json string
   value <- data.frame("carb" = 8L,
-                      "json" = '{"mpg": 123, "gear": 3}',
+                      "json1" = '{"mpg": 123, "gear": 3}',
+                      "json2" = '{"gear": 456}',
                       stringsAsFactors = FALSE)
-  expect_equal((docdb_update(src = con, key = "mtcars", value = value)), 1L)
+  expect_equal(docdb_update(src = con, key = "mtcars", value = value), 1L)
   tmp <- docdb_get(con, "mtcars")
-  expect_true(all(tmp[["gear"]][tmp[["mpg"]] == 123L] == 3L))
-  expect_true(all(is.na(tmp[["carb"]][tmp[["mpg"]] == 123L])))
+  expect_true(tmp[["carb"]][tmp[["mpg"]] == 123L] == 8L)
+  expect_true(tmp[["gear"]][tmp[["mpg"]] == 123L] == 456L)
   
 })


### PR DESCRIPTION
Hello, this is a PR to improve on my initial implementation of docdb_update() for src_sqlite() objects (PR #30 ). That implementation just replaced an existing record with a fully new record. 

Now, json_patch() of the Json1 extension in the SQLite backend is used to enable atomic updates (of parts of the JSON document), see [https://www.sqlite.org/json1.html#jpatch](https://www.sqlite.org/json1.html#jpatch). 

This is much more appropriate for an docdb_update() method, and I hope you can accept this. Thanks for review and comments. 