### PR TITLE
Fix for handling multibyte characters in JSON strings when using src_sqlite() 

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -117,6 +117,9 @@ docdb_get.src_sqlite <- function(src, key, limit = NULL, ...) {
   dump <- file(description = tfname,
                encoding = "UTF-8")
   
+  # register to remove file
+  # after used for streaming
+  on.exit(unlink(tfname))
   
   # get data, write to file in ndjson format
   cat(stats::na.omit(unlist(
@@ -127,7 +130,7 @@ docdb_get.src_sqlite <- function(src, key, limit = NULL, ...) {
   sep = "\n", # ndjson
   file = dump)
   
-  # from jsonlite:
+  # from jsonlite documentation:
   # Because parsing huge JSON strings is difficult and inefficient, 
   # JSON streaming is done using lines of minified JSON records, a.k.a. ndjson. 
   jsonlite::stream_in(dump, verbose = FALSE)

--- a/R/get.R
+++ b/R/get.R
@@ -112,9 +112,11 @@ docdb_get.src_sqlite <- function(src, key, limit = NULL, ...) {
   n <- -1L
   if (!is.null(limit)) n <- limit
   
-  # temporary file; note this cannot be deleted
-  # because it is streamed into the return value
-  dump <- tempfile()
+  # temporary file for streaming
+  tfname <- tempfile()
+  dump <- file(description = tfname,
+               encoding = "UTF-8")
+  
   
   # get data, write to file in ndjson format
   cat(stats::na.omit(unlist(
@@ -128,7 +130,7 @@ docdb_get.src_sqlite <- function(src, key, limit = NULL, ...) {
   # from jsonlite:
   # Because parsing huge JSON strings is difficult and inefficient, 
   # JSON streaming is done using lines of minified JSON records, a.k.a. ndjson. 
-  jsonlite::stream_in(file(dump), verbose = FALSE)
+  jsonlite::stream_in(dump, verbose = FALSE)
 
 }
 

--- a/R/query.R
+++ b/R/query.R
@@ -257,17 +257,17 @@ docdb_query.src_sqlite <- function(src, key, query, ...) {
   
   ## do query
   
-  # temporary file; note this cannot be 
-  # because it is needed to stream 
-  # the return value
-  dump <- tempfile()
+  # temporary file for streaming
+  tfname <- tempfile()
+  dump <- file(description = tfname,
+               encoding = "UTF-8")
+  
   
   # get data, write to file in ndjson format
   cat(stats::na.omit(unlist(
     DBI::dbGetQuery(conn = src$con,
                     statement = statement, 
-                    n = n)
-  )
+                    n = n))
   ),
   sep = "\n", # ndjson
   file = dump)
@@ -275,7 +275,7 @@ docdb_query.src_sqlite <- function(src, key, query, ...) {
   # from jsonlite:
   # Because parsing huge JSON strings is difficult and inefficient, 
   # JSON streaming is done using lines of minified JSON records, a.k.a. ndjson. 
-  jsonlite::stream_in(file(dump), verbose = FALSE)
+  jsonlite::stream_in(dump, verbose = FALSE)
 
 }
 

--- a/R/query.R
+++ b/R/query.R
@@ -262,6 +262,9 @@ docdb_query.src_sqlite <- function(src, key, query, ...) {
   dump <- file(description = tfname,
                encoding = "UTF-8")
   
+  # register to remove file
+  # after used for streaming
+  on.exit(unlink(tfname))
   
   # get data, write to file in ndjson format
   cat(stats::na.omit(unlist(
@@ -272,7 +275,7 @@ docdb_query.src_sqlite <- function(src, key, query, ...) {
   sep = "\n", # ndjson
   file = dump)
   
-  # from jsonlite:
+  # from jsonlite documentation:
   # Because parsing huge JSON strings is difficult and inefficient, 
   # JSON streaming is done using lines of minified JSON records, a.k.a. ndjson. 
   jsonlite::stream_in(dump, verbose = FALSE)


### PR DESCRIPTION
This PR fixes an perhaps rare error of functions `docdb_{get,query}()` when using an `src_sqlite()` connection with certain multibyte characters in the JSON data, under Windows. The error reads, 
```
> nodbi::docdb_get(src, key)
Error in FUN(X[[i]], ...) : invalid multibyte string, element 1
```
To address the issue, the streaming of the JSON string using `cat` was changed to use a connection object, because the latter permits to specify an encoding (UTF-8, compare `help(connections)`, section Encoding). Into this PR, the removal of the temporary file was added (which I previously overlooked). 