### PR TITLE
Handle keys that have mixed values, array and other types - src_sqlite()

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -214,7 +214,7 @@ docdb_create.src_sqlite <- function(src, key, value, ...){
     #     all(sapply(value, jsonlite::validate))) {
     
     # process json row by row
-    value2 <- sapply(X = seq_len(nrow(value)), 
+    value2 <- lapply(X = seq_len(nrow(value)), 
                      FUN = function(x) {
                        
                        # get row from data frame
@@ -260,12 +260,8 @@ docdb_create.src_sqlite <- function(src, key, value, ...){
                      })
     
     # value included json subelements
-    value <- data.frame(
-      "_id" = value2[[1]],
-      "json" = value2[[2]],
-      stringsAsFactors = FALSE,
-      check.names = FALSE)
-    
+    value <- do.call(rbind, value2)
+        
   } else { 
     
     # no json in dataframe, 


### PR DESCRIPTION
Some JSON datasets have mixed types of values of the same key in different records. Consider for example these two records: `[{"a_key": "a text value"},{"a_key": ["text one", "text two"]}]`. This scenario was not handled well by `docdb_query.src_sqlite` so far. 
 
## Description
The edits concern how the SQL statement is built and in particular, how SQLite's JSON1's functions are used to extract objects. Depending on the type of the value, the object is wrapped into an `json_array` call. This was added for mixed-type-values to the existing escaping and extracting code. At this occasion, I noticed that `docdb_create.src_sqlite()` was not robust for data where the json string does not include an _id. The method now is robust after changing to a simpler list handling. 

## Example

```
dbc <- nodbi::src_sqlite(
  key = "myTable")

nodbi::docdb_create(
  src = dbc, 
  key = 'myTable', 
  value = data.frame(
    "_id" = c("01", "02"),
    "json" = c('{"a_key": "a text value"}', '{"a_key": ["text one", "text two"]}'),
    stringsAsFactors = FALSE,
    check.names = FALSE)
    )

nodbi::docdb_get(
  src = dbc, 
  key = 'myTable'
)

nodbi::docdb_query(
  src = dbc, 
  key = 'myTable', 
  query = '{}',
  fields = '{"a_key": 1}')
```

