### PR TITLE
Feature addition: handle arrays and nested content with RSQLite backend

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -129,8 +129,7 @@ docdb_query.src_sqlite <- function(src, key, query, ...) {
       conn = src$con, 
       statement = paste0(
         "SELECT DISTINCT fullkey, type
-         FROM ", key, ", json_tree (", key, ".json) AS tt
-         WHERE tt.type <> 'object';"
+         FROM ", key, ", json_tree (", key, ".json) AS tt;"
       )))
   
   ## convert parameter fields

--- a/R/query.R
+++ b/R/query.R
@@ -74,7 +74,7 @@ docdb_query <- function(src, key, query, ...){
 
 #' @export
 docdb_query.default <- function(src, key, query, ...) {
-  stop("docdb_query supported for CouchDB, Elasticsearch & MongoDB")
+  stop("docdb_query supported for CouchDB, Elasticsearch, MongoDB & SQLite")
 }
 
 #' @export

--- a/R/src_sqlite.R
+++ b/R/src_sqlite.R
@@ -67,14 +67,14 @@ print.src_sqlite <- function(x, ...) {
   srv <- rev(RSQLite::rsqliteVersion())[1]
   cat(sprintf("SQLite library version: %s\n size: %s kBytes\n dbname: %s\n",
               srv, dbsize / 2^10, dbname))
-  
+
   if (grepl(":memory:", dbname)) {
-    warning("Database is only in memory, will not persist after R ends! Consider to copy it with \n", 
-            "RSQLite::sqliteCopyDatabase(\n", 
-            "  from = <your nodbi::src_sqlite() object>$con, \n", 
-            "  to = <e.g. RSQLite::SQLite(dbname = 'local_file.db')>\n", 
-            "  )", 
+    warning("Database is only in memory, will not persist after R ends! Consider to copy it with \n",
+            "RSQLite::sqliteCopyDatabase(\n",
+            "  from = <your nodbi::src_sqlite() object>$con, \n",
+            "  to = <e.g. RSQLite::dbConnect(RSQLite::SQLite(), 'local_file.db')>\n",
+            "  )",
             call. = FALSE)
   }
-  
+
 }

--- a/man/docdb_query.Rd
+++ b/man/docdb_query.Rd
@@ -41,7 +41,7 @@ you may be better of using \pkg{elastic} package directly
 help with searches
 \item SQLite: \code{fields}, an optional json string of fields to be
 returned from anywhere in the tree.
-Parameter \code{query}, a json string In analogy to MongoDB,
+Parameter \code{query}, a json string. In analogy to MongoDB,
 a comma separated list of expressions provides an implicit
 AND operation. Nested or otherwise complex queries are not
 yet supported.

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -121,7 +121,15 @@ test_that("query in sqlite works", {
                 fields = '{"age": 1, "friends[1].id": 1}', 
                 query = '{"_id": "5cd6785335b63cb19dfa8347"}')[["age"]],
     30L)
-  
+
+  expect_equal(
+    length(
+      docdb_query(
+        con, "mtcars",
+        fields = '{"age": 1, "friends": 1}',
+        query = '{"_id": "5cd6785335b63cb19dfa8347"}')[["friends"]][[1]][["name"]]),
+    3L)
+
 })
 
 context("sqlitedb: update")


### PR DESCRIPTION
The purpose is to extend and essentially complete handling json data with the RSQLite backend. 

## Description

So far docdb_query.src_sqlite would not return values from all records those fields that are arrays, but only selected records such as field[1].subfield. This was because `json_extract()` was used which requires a full json path (https://www.sqlite.org/json1.html#jex). Handling this situation was not included in my initial implementation of nodbi functions for the RSQLite backend. The PR intends to cover this important use case. 

## Example

The `contacts` are a json string that is part of the nodbi package and its `friends` field has subitems with keys `name` and `id`. With this PR, `friends` in the returned data.frame is column that is a list with one data.frame per row (or list item).  

```
con <- src_sqlite()

docdb_create(con, "contacts", value = data.frame(contacts, stringsAsFactors = FALSE)))

docdb_query(con, "contacts", fields = '{"friends": 1}', query = '{}')
#                                                     friends                      _id
# 1 0, 1, 2, Wooten Goodwin, Brandie Woodward, Angelique Britt 5cd67853f841025e65ce0ce2
# 2                                0, 1, Yang Yates, Lacy Chen 5cd678531b423d5f04cfb0a1
# 3      0, 1, 2, Coleen Dunn, Doris Phillips, Concetta Turner 5cd6785335b63cb19dfa8347
# 4      0, 1, 2, Baird Keller, Francesca Reese, Dona Bartlett 5cd6785325ce3a94dfc54096
# 5                                               0, Pace Bell 5cd678530df22d3625ed8375

str(docdb_query(con, "contacts", fields = '{"friends": 1}', query = '{}'))
# 'data.frame':	5 obs. of  2 variables:
#  $ friends:List of 5
#   ..$ :'data.frame':	3 obs. of  2 variables:
#   .. ..$ id  : int  0 1 2
#   .. ..$ name: chr  "Wooten Goodwin" "Brandie Woodward" "Angelique Britt"
#   ..$ :'data.frame':	2 obs. of  2 variables:
```
