### PR TITLE
src_sqlite: fix for table / collection names with special characters

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -31,7 +31,7 @@
 #' src <- src_mongo(collection = "mtcars")
 #' docdb_create(src, key = "mtcars", value = mtcars)
 #' docdb_get(src, "mtcars")
-#' 
+#'
 #' # SQLite
 #' src <- src_sqlite()
 #' if (docdb_exists(src, "mtcars")) docdb_delete(src, "mtcars")
@@ -70,244 +70,244 @@ docdb_create.src_redis <- function(src, key, value, ...) {
 
 #' @export
 docdb_create.src_mongo <- function(src, key, value, ...){
-  
+
   assert(value, 'data.frame')
-  
+
   # check expectations
-  if (exists("key", inherits = FALSE) && 
-      src$collection != key) 
+  if (exists("key", inherits = FALSE) &&
+      src$collection != key)
     message("Parameter 'key' is different from parameter 'collection', ",
             "was given as ", src$collection, " in src_mongo().")
-  
+
   # Document identifier is created by mongolite
-  # from _id column or row.names of dataframe "value". 
+  # from _id column or row.names of dataframe "value".
   # If dataframe has _id column, ensure it is character
   # to emulate how row.names is used by mongolite.
-  
+
   if (any(grepl("_id", names(value)))) {
     value[["_id"]] <- as.character(value[["_id"]])
   }
-  
-  # mongolite: 
+
+  # mongolite:
   # insert(data, pagesize = 1000, stop_on_error = TRUE, ...)
-  # 
-  # Insert rows into the collection. 
-  # Argument 'data' must be a 
-  # - data-frame, 
-  # - named list (for single record) or 
-  # - character vector with json strings (one string for each row). 
-  # 
-  # For lists and data frames, arguments 
+  #
+  # Insert rows into the collection.
+  # Argument 'data' must be a
+  # - data-frame,
+  # - named list (for single record) or
+  # - character vector with json strings (one string for each row).
+  #
+  # For lists and data frames, arguments
   # in ... get passed to jsonlite::toJSON
-  
+
   # check if _id in data.frame
   idcol <- grep("_id", names(value))
   valcol <- 1L + ifelse(length(idcol), 1L, 0L)
-  
-  # Check if data.frame has one or two 
+
+  # Check if data.frame has one or two
   # columns where the non-_id column is
-  # already filled with json strings: 
+  # already filled with json strings:
   if (ncol(value) == (1L + ifelse(length(idcol) != 0L, 1L, 0L)) &&
       all(sapply(value[, valcol], is.character)) &&
       all(sapply(value[, valcol], jsonlite::validate))) {
-    
+
     # True, thus now add json strings as documents.
     # Iterate over rows if any in data.frame value
     nrowaffected <- sapply(seq_len(nrow(value)), function(i) {
-      
+
       # minify
       value[i, valcol] <- as.character(jsonlite::minify(value[i, valcol]))
-      
+
       # check if subids (_id's) in json strings, extract them
       subids <- gregexpr('"_id":".*?"', value[i, valcol])
       subids <- regmatches(value[i, valcol], subids)
       subids <- sub(".*:\"(.*)\".*", "\\1", unlist(subids))
-      
+
       if (length(subids)) {
-        
-        # if not in square brackets, add them 
+
+        # if not in square brackets, add them
         if (!grepl("^\\[.*\\]$", value[i, valcol]))
           value[i, -idcol] <- paste0('[', value[i, valcol], ']')
-        
+
         # splice value element into json elements
         subvalue <- jsonlite::fromJSON(value[i, valcol], simplifyVector = FALSE)
         subvalue <- sapply(subvalue, function(x) jsonlite::toJSON(x, auto_unbox = TRUE))
-        
+
         # iterate over elements and each has an _id
         sapply(seq_along(subvalue), function(ii){
-          
+
           # insert
           src$con$insert(subvalue[ii], ...)$nInserted
-          
+
         })
-        
+
       } else {# no subids
-        
-        # add _id into beginning of json string, 
+
+        # add _id into beginning of json string,
         # if the json string does not yet have it.
         tmpvalue <- value[i, valcol, drop = TRUE]
-        if (length(idcol) && !grepl('"_id"', tmpvalue)) 
-          tmpvalue <- jsonlite::toJSON(c(list("_id" = value[i, idcol, drop = TRUE]), 
+        if (length(idcol) && !grepl('"_id"', tmpvalue))
+          tmpvalue <- jsonlite::toJSON(c(list("_id" = value[i, idcol, drop = TRUE]),
                                          jsonlite::fromJSON(tmpvalue)), auto_unbox = TRUE)
-        
+
         # insert
         src$con$insert(data = tmpvalue, ...)$nInserted
-        
+
       }
-      
+
     })
-    
+
   } else {# no character vecto with json strings in data.frame
-    
+
     # standard method to add data.frame
     nrowaffected <- src$con$insert(data = value, ...)$nInserted
-    
+
   }
-  
+
   # return number of created rows in table
   return(invisible(sum(nrowaffected, na.rm = TRUE)))
-  
+
 }
 
 #' @export
 docdb_create.src_sqlite <- function(src, key, value, ...){
-  
+
   assert(value,  "data.frame")
   assert(key, "character")
-  
+
   ### if table does not exist, create one
   if (!docdb_exists(src, key)) {
-    
+
     ### defining the standard for a nodbi json table in sqlite:
     # CREATE TABLE mtcars ( _id TEXT PRIMARY_KEY NOT NULL, json JSON );
     # CREATE UNIQUE INDEX mtcars_index ON mtcars ( _id );
     DBI::dbExecute(
-      conn = src$con, 
-      statement = paste0("CREATE TABLE ", key, 
-                         " ( _id TEXT PRIMARY_KEY NOT NULL,", 
+      conn = src$con,
+      statement = paste0("CREATE TABLE \"", key, "\"",
+                         " ( _id TEXT PRIMARY_KEY NOT NULL,",
                          "  json JSON);"))
     DBI::dbExecute(
-      conn = src$con, 
-      statement = paste0("CREATE UNIQUE INDEX ", 
-                         key, "_index ON ",
-                         key, " ( _id );"))
+      conn = src$con,
+      statement = paste0("CREATE UNIQUE INDEX ",
+                         "\"", key, "_index\" ON ",
+                         "\"", key, "\" ( _id );"))
   }
-  
-  ### return if no value provided, 
+
+  ### return if no value provided,
   # such as to create empty table
   if (is.null(value)) return(invisible(0L))
-  
+
   # check if _id in data.frame
   idcol <- grep("_id", names(value))
   valcol <- 1L + ifelse(length(idcol), 1L, 0L)
-  
-  # Check if data.frame has one or two 
+
+  # Check if data.frame has one or two
   # columns where the non-_id column is
-  # already filled with json strings: 
+  # already filled with json strings:
   if (ncol(value) == (1L + ifelse(length(idcol) != 0L, 1L, 0L)) &&
       all(sapply(value[, valcol], is.character)) &&
       all(sapply(value[, valcol], jsonlite::validate))) {
-    
+
     # # convert dataframe rows into json
     # # respect any pre-existing json
     # if (all(sapply(value, is.character)) &&
     #     all(sapply(value, jsonlite::validate))) {
-    
+
     # process json row by row
-    value2 <- lapply(X = seq_len(nrow(value)), 
+    value2 <- lapply(X = seq_len(nrow(value)),
                      FUN = function(x) {
-                       
+
                        # get row from data frame
                        tmp <- value[x, valcol]
-                       
+
                        # minify for regexp
                        tmp <- as.character(jsonlite::minify(tmp))
-                       
+
                        # check if _id's in json and get them
                        subids <- gregexpr('"_id":".*?"', tmp)
                        subids <- regmatches(tmp, subids)
                        subids <- sub(".*:\"(.*)\".*", "\\1", unlist(subids))
                        #
                        if (length(subids)) {
-                         
-                         # if not in square brackets, add them 
+
+                         # if not in square brackets, add them
                          if (!grepl("^\\[.*\\]$", tmp)) {
                            tmp <- paste0('[', tmp, ']')
                          }
-                         
+
                          # remove _ids
                          tmp <- gsub('"_id":".*?",', "", tmp)
-                         
+
                          # splice tmp element into json elements and merge again
                          subvalue <- jsonlite::fromJSON(tmp, simplifyVector = FALSE)
                          subvalue <- sapply(subvalue, function(x) jsonlite::toJSON(x, auto_unbox = TRUE))
-                         
+
                          # output
-                         data.frame("_id" = subids, 
-                                    "json" = subvalue, 
+                         data.frame("_id" = subids,
+                                    "json" = subvalue,
                                     stringsAsFactors = FALSE,
                                     check.names = FALSE)
-                         
+
                        } else {
-                         
+
                          # output
-                         data.frame("_id" = value[x, idcol], 
-                                    "json" = tmp, 
+                         data.frame("_id" = value[x, idcol],
+                                    "json" = tmp,
                                     stringsAsFactors = FALSE,
                                     check.names = FALSE)
-                         
+
                        }
                      })
-    
+
     # value included json subelements
     value <- do.call(rbind, value2)
-        
-  } else { 
-    
-    # no json in dataframe, 
+
+  } else {
+
+    # no json in dataframe,
     # transform row into json
     dump <- tempfile()
     dumpcon <- file(dump)
-    
+
     # this is fastest using ndjson
     if (length(idcol) == 0L) {
       # no idcol
       jsonlite::stream_out(
         x = value,
-        con = dumpcon, 
+        con = dumpcon,
         verbose = FALSE)
     } else {
       # has idcol
       jsonlite::stream_out(
-        x = value[ -idcol ], 
-        con = dumpcon, 
+        x = value[ -idcol ],
+        con = dumpcon,
         verbose = FALSE)
     }
-    
-    # read back in as json    
+
+    # read back in as json
     value <- data.frame(
       "_id" = ifelse(
         test = rep(length(idcol), nrow(value)),
-        yes = as.character(value[["_id"]]), 
+        yes = as.character(value[["_id"]]),
         no = row.names(value)),
       "json" = readLines(dump),
       stringsAsFactors = FALSE,
       check.names = FALSE)
-    
+
     # cleanup
     unlink(dump)
   }
-  
+
   ### load into database
-  nrowaffected <- 
+  nrowaffected <-
     DBI::dbAppendTable(
-      conn = src$con, 
-      name = key, 
+      conn = src$con,
+      name = key,
       value = value,
       ...)
-  
+
   return(invisible(nrowaffected))
-  
+
 }
 
 ## helpers --------------------------------------

--- a/R/delete.R
+++ b/R/delete.R
@@ -32,7 +32,7 @@
 #' docdb_create(src, "iris", iris)
 #' docdb_get(src, "iris")
 #' docdb_delete(src, "iris")
-#' 
+#'
 #' # SQLite
 #' src <- src_sqlite()
 #' docdb_create(src, "iris", iris)
@@ -63,30 +63,30 @@ docdb_delete.src_redis <- function(src, key, ...) {
 
 #' @export
 docdb_delete.src_mongo <- function(src, key, ...) {
-  
+
   # check expectations
-  if (exists("key", inherits = FALSE) && 
-      src$collection != key) 
+  if (exists("key", inherits = FALSE) &&
+      src$collection != key)
     message("Parameter 'key' is different from parameter 'collection', ",
             "was given as ", src$collection, " in src_mongo().")
-  
+
   # https://docs.mongodb.com/manual/tutorial/remove-documents/
   # https://jeroen.github.io/mongolite/manipulate-data.html#remove
-  
+
   # make dotted parameters accessible
   tmpdots <- list(...)
-  
-  # if valid json, try to delete 
+
+  # if valid json, try to delete
   # document(s) instead of collection
-  if (!is.null(tmpdots$query) && 
+  if (!is.null(tmpdots$query) &&
       jsonlite::validate(tmpdots$query)) {
-    
+
     # delete document
-    src$con$remove(query = tmpdots$query, 
+    src$con$remove(query = tmpdots$query,
                    just_one = FALSE)
-    
+
   } else {
-    
+
     # delete collection
     src$con$drop()
 
@@ -96,33 +96,33 @@ docdb_delete.src_mongo <- function(src, key, ...) {
 #' @export
 docdb_delete.src_sqlite <- function(src, key, ...) {
   assert(key, 'character')
-  
+
   # make dotted parameters accessible
   tmpdots <- list(...)
-  
+
   # if valid query, delete document(s), not table
-  if (!is.null(tmpdots$query) && 
+  if (!is.null(tmpdots$query) &&
       jsonlite::validate(tmpdots$query)) {
-    
+
     # get _id's of document to be deleted
-    tmpids <- docdb_query(src = src, 
-                          key = key, 
-                          query = tmpdots$query, 
+    tmpids <- docdb_query(src = src,
+                          key = key,
+                          query = tmpdots$query,
                           fields = '{"_id": 1}')[["_id"]]
-    
+
     # create delete
-    statement <- paste0("DELETE FROM ", key, " WHERE _id IN (", 
+    statement <- paste0("DELETE FROM \"", key, "\" WHERE _id IN (",
                         paste0('"', tmpids, '"', collapse = ','), ");")
 
     # do delete
     DBI::dbExecute(conn = src$con,
                    statement = statement)
-    
+
   } else {
-    
+
     # remove table
-    DBI::dbRemoveTable(conn = src$con, 
+    DBI::dbRemoveTable(conn = src$con,
                        name = key)
-    
+
   }
 }

--- a/R/query.R
+++ b/R/query.R
@@ -24,10 +24,10 @@
 #' help with searches
 #' - SQLite: `fields`, an optional json string of fields to be
 #' returned from anywhere in the tree.
-#' Parameter `query`, a json string In analogy to MongoDB,
-#' a comma separated list of expressions provides an implicit
-#' AND operation. Nested or otherwise complex queries are not
-#' yet supported.
+#' Parameter `query`, a JSON string; supported at the moment:
+#' one level of $or or $and operators with
+#' $eq, $gt, $gte, $lt, $lte, $ne and $regex as tests.
+#'
 #'
 #' @section Not supported yet:
 #'
@@ -74,7 +74,7 @@ docdb_query <- function(src, key, query, ...){
 
 #' @export
 docdb_query.default <- function(src, key, query, ...) {
-  stop("docdb_query supported for CouchDB, Elasticsearch & MongoDB")
+  stop("docdb_query supported for CouchDB, Elasticsearch, MongoDB & SQLite (partially)")
 }
 
 #' @export

--- a/R/src_sqlite.R
+++ b/R/src_sqlite.R
@@ -1,59 +1,59 @@
 #' Setup a sqlite database connection
 #'
 #' @export
-#' 
-#' @param dbname (character) name of database file, 
+#'
+#' @param dbname (character) name of database file,
 #'   defaults to ":memory:" for an in-memory database,
 #'   see [RSQLite::SQLite()]
-#' @param ... additional named parameters passed 
+#' @param ... additional named parameters passed
 #'   on to [RSQLite::SQLite()]
-#' 
+#'
 #' @details uses \pkg{RSQLite} under the hood
-#' 
+#'
 #' @examples \dontrun{
 #' (con <- src_sqlite())
 #' print(con)
 #' }
-#' 
-src_sqlite <- function(dbname = ":memory:", 
+#'
+src_sqlite <- function(dbname = ":memory:",
                        ...) {
 
   # open connection
   con <- DBI::dbConnect(
-    drv = RSQLite::SQLite(), 
-    dbname = dbname, 
+    drv = RSQLite::SQLite(),
+    dbname = dbname,
     ...)
-  
+
   # check if json1 extension is supported
   if ("try-error" %in% class(
     try(
       DBI::dbExecute(
-        conn = con, 
+        conn = con,
         statement = paste0('SELECT * FROM json_each(\'{"test":"1"}\');')
       ), silent = TRUE)
   )) {
-    stop("SQLite does not have json1 extension enabled. Call ", 
+    stop("SQLite does not have json1 extension enabled. Call ",
          "install.packages('RSQLite') to install a current version.")
   }
-  
+
   # check if regular expressions are supported (RSQLite >= 2.1.2)
   if ("try-error" %in% class(
     try({
       RSQLite::initRegExp(db = con)
       DBI::dbExecute(
-        conn = con, 
+        conn = con,
         statement = paste0('SELECT * FROM (VALUES ("Astring")) WHERE 1 REGEXP "[A-Z][a-z]+";'))
-      }, silent = TRUE)
+    }, silent = TRUE)
   )) {
     attr(x = con, which = "regexp.extension") <- FALSE
   } else {
     attr(x = con, which = "regexp.extension") <- TRUE
   }
-  
+
   # return standard nodbi structure
-  structure(list(con = con, 
-                 dbname = dbname, 
-                 ...), 
+  structure(list(con = con,
+                 dbname = dbname,
+                 ...),
             class = c("src_sqlite", "docdb_src"))
 
 }
@@ -67,14 +67,14 @@ print.src_sqlite <- function(x, ...) {
   srv <- rev(RSQLite::rsqliteVersion())[1]
   cat(sprintf("SQLite library version: %s\n size: %s kBytes\n dbname: %s\n",
               srv, dbsize / 2^10, dbname))
-  
+
   if (grepl(":memory:", dbname)) {
-    warning("Database is only in memory, will not persist after R ends! Consider to copy it with \n", 
-            "RSQLite::sqliteCopyDatabase(\n", 
-            "  from = <your nodbi::src_sqlite() object>$con, \n", 
-            "  to = <e.g. RSQLite::SQLite(dbname = 'local_file.db')>\n", 
-            "  )", 
+    warning("Database is only in memory, will not persist after R ends! Consider to copy it with \n",
+            "RSQLite::sqliteCopyDatabase(\n",
+            "  from = <your nodbi::src_sqlite() object>$con, \n",
+            "  to = <e.g. RSQLite::dbConnect(RSQLite::SQLite(), 'local_file.db')>\n",
+            "  )",
             call. = FALSE)
   }
-  
+
 }

--- a/R/update.R
+++ b/R/update.R
@@ -15,7 +15,7 @@
 #' mtcars$letter <- sample(letters, NROW(mtcars), replace = TRUE)
 #' invisible(docdb_update(src, "mtcars2", mtcars))
 #' docdb_get(src, "mtcars2")
-#' 
+#'
 #' # MongoDB
 #' src <- src_mongo(collection = "mtcars")
 #' docdb_create(src, key = "mtcars", value = mtcars)
@@ -31,7 +31,7 @@
 #'                     check.names = FALSE)
 #' docdb_update(src, "mtcars", value)
 #' docdb_get(src, "mtcars")
-#' 
+#'
 #' # SQLite
 #' src <- src_sqlite()
 #' docdb_create(src, "mtcars", mtcars)
@@ -64,46 +64,46 @@ docdb_update.src_couchdb <- function(src, key, value, ...) {
 
 #' @export
 docdb_update.src_mongo <- function(src, key, value, ...) {
-  
+
   # check expectations
-  if (exists("key", inherits = FALSE) && 
-      src$collection != key) 
+  if (exists("key", inherits = FALSE) &&
+      src$collection != key)
     message("Parameter 'key' is different from parameter 'collection', ",
             "was given as ", src$collection, " in src_mongo().")
-  
-  # The aim is to use this method: 
+
+  # The aim is to use this method:
   # mongolite::mongo()$update(query, update = '{"$set":{}}', upsert = FALSE, multiple = FALSE)
-  # It is necessary to define: 
-  # - which documents to update (based on parameter "query" if specified, 
+  # It is necessary to define:
+  # - which documents to update (based on parameter "query" if specified,
   #   or column _id in dataframe value, or all documents in collection)
-  # - what to use for updating (the dataframe value will be converted 
+  # - what to use for updating (the dataframe value will be converted
   #   into a set of changes, where column names indicate what element
-  #   in the document to update, and will be replaced with non-NA values 
+  #   in the document to update, and will be replaced with non-NA values
   #   in the dataframe for the respective document)
-  
+
   assert(value, 'data.frame')
-  
+
   # Get ellipsis
   dotparams <- list(...)
-  
-  # Which documents to update? 
+
+  # Which documents to update?
   # - Check if query is specified
-  query <- rep.int(x = ifelse(is.null(dotparams$query), "{}", dotparams$query), 
+  query <- rep.int(x = ifelse(is.null(dotparams$query), "{}", dotparams$query),
                    times = nrow(value))
-  
+
   # - Is _id in dataframe value?
   if (all(query != "{}") & any(grepl("_id", names(value)))) {
     stop("Specify only one of query = '...' or '_id' as column in data frame 'value'.")
   }
-  
+
   # - Get query from dataframe value
   if (any(grepl("_id", names(value)))) {
-    # if dataframe has has a column _id, 
+    # if dataframe has has a column _id,
     # turn it into query and then remove it
     query <- paste0('{"_id":"', value[["_id"]], '"}')
     value <- value[, -match("_id", names(value)), drop = FALSE]
   } else {
-    # if dataframe has at least two columns, 
+    # if dataframe has at least two columns,
     # use FIRST for query and remove it
     if (ncol(value) >= 2L) {
       quoting <- ifelse(class(value[, 1]) == "character", "\"", "")
@@ -112,195 +112,195 @@ docdb_update.src_mongo <- function(src, key, value, ...) {
       value <- value[, -1, drop = FALSE]
     }
   }
-  
+
   # What to use for update`
-  # - Convert dataframe value's rows into vector of 
-  #   json sets. Note: NAs are removed by toJSON. 
-  #   No conversion if already json string. 
-  value <- sapply(X = seq_len(nrow(value)), 
-                  FUN = function(i) 
-                    ifelse(!is.character(value[i,]) || 
+  # - Convert dataframe value's rows into vector of
+  #   json sets. Note: NAs are removed by toJSON.
+  #   No conversion if already json string.
+  value <- sapply(X = seq_len(nrow(value)),
+                  FUN = function(i)
+                    ifelse(!is.character(value[i,]) ||
                              !jsonlite::validate(value[i,]),
-                           jsonlite::toJSON(x = value[i, , drop = FALSE], 
+                           jsonlite::toJSON(x = value[i, , drop = FALSE],
                                             dataframe = "rows",
-                                            auto_unbox = TRUE), 
+                                            auto_unbox = TRUE),
                            value[i,]))
-  
+
   # - Remove outer []
-  value <- gsub(pattern = "^\\[|\\]$", 
+  value <- gsub(pattern = "^\\[|\\]$",
                 replacement = "",
                 x = value)
-  
+
   # - Turn into json set
   value <- paste0('{"$set":', value, '}')
-  
+
   # - To update, iterate over json set vector
   nrowaffected <-
-    sapply(seq_len(length(value)), 
-           function(i) 
+    sapply(seq_len(length(value)),
+           function(i)
              # update(query, update = '{"$set":{}}', upsert = FALSE, multiple = FALSE)
              src$con$update(query = query[i],  # which documents?
-                            update = value[i], # with what to update? 
+                            update = value[i], # with what to update?
                             upsert = TRUE,     # ok to add new documents
                             multiple = TRUE)   # ok to update several documents
     )
-  
+
   # Extract number of modified or added documents
-  #               [,1]         
-  # modifiedCount 0            
-  # matchedCount  0            
-  # upsertedCount 1            
+  #               [,1]
+  # modifiedCount 0
+  # matchedCount  0
+  # upsertedCount 1
   # upsertedId    "NCT00097292"
-  nrowaffected <- data.frame(nrowaffected, 
+  nrowaffected <- data.frame(nrowaffected,
                              stringsAsFactors = FALSE)[c(1, 3), , drop = TRUE]
-  
+
   invisible(sum(unlist(nrowaffected), na.rm = TRUE))
-  
+
 }
 
-#' @export                  
+#' @export
 docdb_update.src_sqlite <- function(src, key, value, ...) {
-  
+
   assert(key, "character")
-  assert(value, 'data.frame') 
-  
+  assert(value, 'data.frame')
+
   # If table does not exist, create empty table
   if (!docdb_exists(src = src, key = key)) {
     docdb_create(src = src, key = key, value = NULL)
   }
-  
-  # value: data frame where first column has the name _id 
-  # or the name of a variable in the data-to-be-updated; 
-  # the rows of the data frame value then have values 
-  # that identify the records that are to be updated. 
-  # 
-  # When the data frame value has only two columns and the
-  # second column consists of json strings, these json 
-  # sets will be used to update (json_patch) the data-to-
-  # be-updated, https://www.sqlite.org/json1.html#jpatch 
 
-  # Check data frame value  
+  # value: data frame where first column has the name _id
+  # or the name of a variable in the data-to-be-updated;
+  # the rows of the data frame value then have values
+  # that identify the records that are to be updated.
+  #
+  # When the data frame value has only two columns and the
+  # second column consists of json strings, these json
+  # sets will be used to update (json_patch) the data-to-
+  # be-updated, https://www.sqlite.org/json1.html#jpatch
+
+  # Check data frame value
   vn <- names(value)
-  
+
   if ("_id" != vn[1]) {
-    
+
     # get _id of records to be updated
     idsaffected <- sapply(seq_len(nrow(value)), function(i) {
-      
+
       statement <- sprintf(
         "SELECT _id
-         FROM %s, json_each( %s.json )
+         FROM \"%s\", json_each(\"%s\".json)
          WHERE key = '%s'
          AND value = %s;",
         key, key,
-        vn[1], 
-        ifelse(inherits(value[i, 1], "character"), 
+        vn[1],
+        ifelse(inherits(value[i, 1], "character"),
                paste0("'", value[i , 1], "'"),
                value[i , 1])
       )
-      
-      DBI::dbGetQuery(conn = src$con, 
+
+      DBI::dbGetQuery(conn = src$con,
                       statement = statement)
     })
-    
+
     # replace first column with _id
     value <- lapply(seq_len(nrow(value)), function(i) {
-      
-      tmp <- data.frame(idsaffected[i], 
-                        value[i, -1], 
+
+      tmp <- data.frame(idsaffected[i],
+                        value[i, -1],
                         stringsAsFactors = FALSE,
                         check.rows = FALSE,
                         row.names = NULL)
-      
+
       names(tmp) <- c("_id", vn[-1])
-      
+
       tmp
-      
+
     })
-    
+
     # make new value data frame
     value <- do.call(rbind, value)
-    
+
   }
 
   # iterate over rows to handle any mixed data
   nrowiterated <- sapply(seq_len(nrow(value)), function(i) {
-    
+
     # get row except first column,
     # which identifies the records
     # that are to be updated
     tmpval <- value[i, -1, drop = FALSE]
 
     # all values in these columns json?
-    # if (all(is.character(tmpval)) && 
-    if (all(sapply(tmpval, 
-                   function(col) 
-                     is.character(col) && 
+    # if (all(is.character(tmpval)) &&
+    if (all(sapply(tmpval,
+                   function(col)
+                     is.character(col) &&
                      jsonlite::validate(col)))) {
-      
+
       # iterate over columns
       ncoliterated <- sapply(tmpval, function(ii) {
-        
+
         # construct sql statment
         statement <- sprintf(
-          "UPDATE %s
-           SET json = json_patch ( %s.json, %s )
+          "UPDATE \"%s\"
+           SET json = json_patch (\"%s\".json, %s )
            WHERE _id = '%s';",
-          key, 
+          key,
           key, valueEscape(ii),
           value[i, 1]
         )
-        
+
         # execute sql statement
         DBI::dbExecute(
           conn = src$con,
           statement = statement)
-        
+
       }) # by column with json
-      
+
       # return number of records modified
       sum(ncoliterated, na.rm = TRUE) >= 1L
-      
+
     } else {# no json
-      
+
       # construct json from columns
       tmpval <- jsonlite::toJSON(jsonlite::unbox(tmpval))
 
       # construct sql statement
       statement <- sprintf(
-        "UPDATE %s
-         SET json = json_patch ( %s.json, %s )
+        "UPDATE \"%s\"
+         SET json = json_patch (\"%s\".json, %s )
          WHERE _id = '%s';",
-        key, 
+        key,
         key, valueEscape(tmpval),
         value[i, 1]
       )
-      
+
       # execute sql statement
       DBI::dbExecute(
         conn = src$con,
         statement = statement)
-      
+
     } # no json
-      
+
   })
-  
+
   # return value
   invisible(sum(nrowiterated, na.rm = TRUE))
-  
+
 }
 
 
 ## helpers --------------------------------------
 
 valueEscape <- function(x) {
-  
-  # cf. https://www.sqlite.org/json1.html#jset  
+
+  # cf. https://www.sqlite.org/json1.html#jset
   switch(class(x),
-         
+
          # - character: '"stringvalue"'
-         "character" = ifelse(test = grepl("^[{].*[}]$", trimws(x)), 
-                              yes = paste0('\'', x, '\''), 
+         "character" = ifelse(test = grepl("^[{].*[}]$", trimws(x)),
+                              yes = paste0('\'', x, '\''),
                               no = paste0('\'\"', x, '\"\'')),
          # - list e.g.: '{"a": "something", "b": 2}'
          "list" = paste0('\'', jsonlite::toJSON(x), '\''),
@@ -309,6 +309,6 @@ valueEscape <- function(x) {
          # - default, all others: 'value'
          paste0('\'', x, '\'')
   )
-  
+
 }
 

--- a/man/docdb_query.Rd
+++ b/man/docdb_query.Rd
@@ -41,10 +41,9 @@ you may be better of using \pkg{elastic} package directly
 help with searches
 \item SQLite: \code{fields}, an optional json string of fields to be
 returned from anywhere in the tree.
-Parameter \code{query}, a json string In analogy to MongoDB,
-a comma separated list of expressions provides an implicit
-AND operation. Nested or otherwise complex queries are not
-yet supported.
+Parameter \code{query}, a JSON string; supported at the moment:
+one level of $or or $and operators with
+$eq, $gt, $gte, $lt, $lte, $ne and $regex as tests.
 }
 }
 

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -1,11 +1,11 @@
 context("sqlitedb: src")
 test_that("Source", {
   skip_on_cran()
-  
+
   skip_if_no_sqlite()
   con <- src_sqlite()
-  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
-  
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)
+
   expect_is(con, "docdb_src")
   expect_is(con, "src_sqlite")
   expect_is(con$con, "SQLiteConnection")
@@ -14,40 +14,40 @@ test_that("Source", {
 context("sqlitedb: create")
 test_that("db into sqlite", {
   skip_on_cran()
-  
+
   skip_if_no_sqlite()
   con <- src_sqlite()
-  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
-  
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)
+
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "iris"), error = function(e) e))
-  
+
   iris$Species <- as.character(iris$Species)
   invisible(docdb_create(con, "iris", iris))
-  
+
   invisible(tryCatch(docdb_delete(con, "diamonds"), error = function(e) e))
   d2 <- docdb_get(con, "iris")
   # remove _id column
   d2 <- d2[, -1]
-  
+
   expect_equal(d2, iris)
-  
-  # check if timing acceptable  
+
+  # check if timing acceptable
   docdb_create(con, "diamonds", diamonds)
-  
+
 })
 
 context("sqlitedb: delete")
 test_that("delete in sqlite works", {
   skip_on_cran()
-  
+
   skip_if_no_sqlite()
   con <- src_sqlite()
-  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
-  
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)
+
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "iris"), error = function(e) e))
-  
+
   invisible(docdb_create(con, "iris", iris))
   del <- docdb_delete(con, "iris")
   expect_true(del)
@@ -56,16 +56,16 @@ test_that("delete in sqlite works", {
 context("sqlitedb: exists")
 test_that("exists in sqlite works", {
   skip_on_cran()
-  
+
   skip_if_no_sqlite()
   con <- src_sqlite()
-  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
-  
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)
+
   # delete if exists
   invisible(tryCatch(docdb_delete(con, "iris"), error = function(e) e))
-  
+
   invisible(docdb_create(con, "iris", iris))
-  
+
   expect_true(docdb_exists(con, "iris"))
   expect_false(docdb_exists(con, "doesnotexist"))
 })
@@ -73,135 +73,135 @@ test_that("exists in sqlite works", {
 context("sqlitedb: query")
 test_that("query in sqlite works", {
   skip_on_cran()
-  
+
   skip_if_no_sqlite()
   con <- src_sqlite()
-  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
-  
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)
+
   # delete if exists
-  invisible(tryCatch(docdb_delete(con, "mtcars"), error = function(e) e))
-  
-  invisible(docdb_create(con, "mtcars", mtcars))
-  
+  invisible(tryCatch(docdb_delete(con, "mt-cars"), error = function(e) e))
+
+  invisible(docdb_create(con, "mt-cars", mtcars))
+
   expect_is(
-    docdb_query(con, "mtcars", query = "{}", fields = '{"mpg":1, "cyl": 1}'),
+    docdb_query(con, "mt-cars", query = "{}", fields = '{"mpg":1, "cyl": 1}'),
     "data.frame")
-  
+
   # depending on availability of regular expression operator
   expect_length(
-    docdb_query(con, "mtcars", 
-                query = paste0('{"gear" : 4, "cyl": {"$lte": 8}, "_row": {"$regex": "', 
-                               ifelse(attr(x = con$con, which = "regexp.extension"), 
-                                      '^M[a-z].*', 'M%'), '"} }'), 
+    docdb_query(con, "mt-cars",
+                query = paste0('{"gear" : 4, "cyl": {"$lte": 8}, "_row": {"$regex": "',
+                               ifelse(attr(x = con$con, which = "regexp.extension"),
+                                      '^M[a-z].*', 'M%'), '"} }'),
                 fields = '{"mpg":1, "cyl": 1, "_row": 1}')[["_id"]],
     6L)
-  
-  invisible(docdb_create(con, "mtcars", value = data.frame(contacts, stringsAsFactors = FALSE)))
-  
+
+  invisible(docdb_create(con, "mt-cars", value = data.frame(contacts, stringsAsFactors = FALSE)))
+
   expect_equal(
-    docdb_query(con, "mtcars", 
-                fields = '{"age": 1, "name": 1}', 
+    docdb_query(con, "mt-cars",
+                fields = '{"age": 1, "name": 1}',
                 query = '{"name": "Lacy Chen", "age": {"$lt": 22}}')[["_id"]],
     "5cd678531b423d5f04cfb0a1")
-  
+
   expect_equal(nrow(
-    docdb_query(con, "mtcars", 
-                fields = '{"age": 1, "name": 1}', 
+    docdb_query(con, "mt-cars",
+                fields = '{"age": 1, "name": 1}',
                 query = '{"$or": {"_id": "5cd6785335b63cb19dfa8347", "age": {"$lt": 25}}}')),
     5L)
-  
+
   expect_equal(
-    docdb_query(con, "mtcars", 
-                fields = '{"age": 1, "name": 1}', 
+    docdb_query(con, "mt-cars",
+                fields = '{"age": 1, "name": 1}',
                 query = '{"_id": "5cd6785335b63cb19dfa8347"}')[["name"]],
     "Williamson French")
-  
+
   expect_equal(
-    docdb_query(con, "mtcars", 
-                fields = '{"age": 1, "friends[1].id": 1}', 
+    docdb_query(con, "mt-cars",
+                fields = '{"age": 1, "friends[1].id": 1}',
                 query = '{"_id": "5cd6785335b63cb19dfa8347"}')[["age"]],
     30L)
-  
+
 })
 
 context("sqlitedb: update")
 test_that("update in sqlite works", {
   skip_on_cran()
-  
+
   skip_if_no_sqlite()
   con <- src_sqlite()
-  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)  
-  
+  on.exit(RSQLite::dbDisconnect(con$con), add = TRUE)
+
   # delete if exists
-  invisible(tryCatch(docdb_delete(con, "mtcars"), error = function(e) e))
-  
-  # add data frame into table, 
+  invisible(tryCatch(docdb_delete(con, "mt-cars"), error = function(e) e))
+
+  # add data frame into table,
   # with user-provided _id
   # for subsequent reference
   # in update command
   invisible(
-    docdb_create(con, "mtcars", 
-                 data.frame("_id" = seq_len(nrow(mtcars)), 
-                            mtcars, 
+    docdb_create(con, "mt-cars",
+                 data.frame("_id" = seq_len(nrow(mtcars)),
+                            mtcars,
                             stringsAsFactors = FALSE,
                             # to have _id as column name
-                            check.names = FALSE) 
+                            check.names = FALSE)
     ))
-  
+
   ## test with _id in replacement path
-  
+
   # update - change value of existing key
-  value <- data.frame("_id" = "2", 
+  value <- data.frame("_id" = "2",
                       "gear" = 9,
                       stringsAsFactors = FALSE,
                       # to have _id as column name
-                      check.names = FALSE) 
-  
-  expect_equal(docdb_update(con, "mtcars", value), 1L)
-  tmp <- docdb_query(con, "mtcars", query = "{}", fields = '{"gear": 1}')
+                      check.names = FALSE)
+
+  expect_equal(docdb_update(con, "mt-cars", value), 1L)
+  tmp <- docdb_query(con, "mt-cars", query = "{}", fields = '{"gear": 1}')
   expect_equal(tmp[["gear"]][tmp[["_id"]] == "2"], 9)
-  
+
   # upsert - add key and value not previously present
-  value <- data.frame("_id" = "4", 
+  value <- data.frame("_id" = "4",
                       "a" = 123,
                       stringsAsFactors = FALSE,
                       # to have _id as column name
-                      check.names = FALSE) 
-  
-  expect_equal(docdb_update(con, "mtcars", value), 1L)
-  expect_equal(docdb_query(con, "mtcars", query = "{}", fields = '{"a": 1}')[["a"]], 123)
-  
+                      check.names = FALSE)
+
+  expect_equal(docdb_update(con, "mt-cars", value), 1L)
+  expect_equal(docdb_query(con, "mt-cars", query = "{}", fields = '{"a": 1}')[["a"]], 123)
+
   # multiple - upsert
-  value <- data.frame("_id" = c("3", "5"), 
-                      "gear" = c(99, 66), 
+  value <- data.frame("_id" = c("3", "5"),
+                      "gear" = c(99, 66),
                       "cyl" = c(88, 77),
                       stringsAsFactors = FALSE,
                       # to have _id as column name
-                      check.names = FALSE) 
-  
-  expect_equal(docdb_update(con, "mtcars", value), 2L)
-  tmp <- docdb_query(con, "mtcars", query = "{}", fields = '{"gear": 1, "cyl": 1}')
+                      check.names = FALSE)
+
+  expect_equal(docdb_update(con, "mt-cars", value), 2L)
+  tmp <- docdb_query(con, "mt-cars", query = "{}", fields = '{"gear": 1, "cyl": 1}')
   expect_equal(tmp[["cyl"]][tmp[["_id"]] == "5"], 77)
-  
+
   ## test other paths than _id
   value <- data.frame("gear" = c(3, 4, 5),
                       "a" =    c(8, 7, NA),
                       "b" =    c("b1", NA, "b2"),
                       stringsAsFactors = FALSE)
-  
-  expect_equal(docdb_update(con, "mtcars", value), 29L)
-  tmp <- docdb_get(con, "mtcars")
+
+  expect_equal(docdb_update(con, "mt-cars", value), 29L)
+  tmp <- docdb_get(con, "mt-cars")
   expect_true(all(tmp[["a"]][tmp[["gear"]] == 3] == 8))
   expect_true(all(is.na(tmp[["a"]][tmp[["gear"]] == 5])))
-  
+
   ## test updating with json string
   value <- data.frame("carb" = 8L,
                       "json1" = '{"mpg": 123, "gear": 3}',
                       "json2" = '{"gear": 456}',
                       stringsAsFactors = FALSE)
-  expect_equal(docdb_update(src = con, key = "mtcars", value = value), 1L)
-  tmp <- docdb_get(con, "mtcars")
+  expect_equal(docdb_update(src = con, key = "mt-cars", value = value), 1L)
+  tmp <- docdb_get(con, "mt-cars")
   expect_true(tmp[["carb"]][tmp[["mpg"]] == 123L] == 8L)
   expect_true(tmp[["gear"]][tmp[["mpg"]] == 123L] == 456L)
-  
+
 })


### PR DESCRIPTION
## Description
The result of the changes is that the parameter `key` of functions `docdb_*` now accepts special characters, which so far were not fully escaped in the code for `src_sqlite`. Parameter `key` specifies a table name for `src_sqlite` (and a collection for `src_mongo`). Minor clarifying edits to the corresponding documentation were also included. 

## Related Issue
None

## Example
This now works: 
```
library(nodbi)
con <- src_sqlite()
docdb_create(src = con, key = "table-name-with-dash", value = mtcars)
docdb_query(src = con, key = "table-name-with-dash", query = "{}", fields = '{"mpg":1, "cyl": 1}')
```