### PR TITLE
Use transactions with src_sqlite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Suggests:
     elastic (>= 1.0.0),
     mongolite (>= 1.6),
     redux,
-    RSQLite (>= 1.1),
+    RSQLite (>= 2.2.4),
     DBI,
     testthat
 RoxygenNote: 7.1.1

--- a/R/exists.R
+++ b/R/exists.R
@@ -93,5 +93,5 @@ docdb_exists.src_mongo <- function(src, key, ...) {
 #' @export
 docdb_exists.src_sqlite <- function(src, key, ...) {
   assert(key, 'character')
-  key %in% DBI::dbListTables(src$con)
+  any(key == DBI::dbListTables(src$con))
 }

--- a/R/query.R
+++ b/R/query.R
@@ -431,7 +431,7 @@ json2querySql <- function(x, con) {
   # special case
   # https://docs.mongodb.com/manual/reference/operator/query/regex/#pcre-vs-javascript
   x <- gsub(pattern = "[$]regex:",
-            replacement = ifelse(attr(x = con, which = "regexp.extension"),
+            replacement = ifelse(TRUE,
                                  "REGEXP ", "LIKE "),
             x = x)
 

--- a/R/update.R
+++ b/R/update.R
@@ -252,9 +252,12 @@ docdb_update.src_sqlite <- function(src, key, value, ...) {
         )
 
         # execute sql statement
-        DBI::dbExecute(
-          conn = src$con,
-          statement = statement)
+        dbWithTransaction(
+          src$con, {
+            DBI::dbExecute(
+              conn = src$con,
+              statement = statement)
+          })
 
       }) # by column with json
 
@@ -277,9 +280,12 @@ docdb_update.src_sqlite <- function(src, key, value, ...) {
       )
 
       # execute sql statement
-      DBI::dbExecute(
-        conn = src$con,
-        statement = statement)
+      dbWithTransaction(
+        src$con, {
+          DBI::dbExecute(
+            conn = src$con,
+            statement = statement)
+        })
 
     } # no json
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,3 +26,41 @@ assert <- function(x, y) {
     }
   }
 }
+
+dbWithTransaction <- function(conn, statement) {
+
+  rollback <- function(e) {
+    call <- DBI::dbExecute(conn, "ROLLBACK")
+    if (identical(call, FALSE)) {
+      stop(
+        paste0(
+          "Failed to rollback transaction. ",
+          "Tried to roll back because an error occurred: ",
+          conditionMessage(e)
+        ),
+        call. = FALSE
+      )
+    }
+    if (inherits(e, "error")) {
+      stop(e)
+    }
+  }
+
+  call <- DBI::dbExecute(conn, "BEGIN IMMEDIATE")
+  if (identical(call, FALSE)) {
+    stop("Failed to begin transaction", call. = FALSE)
+  }
+
+  tryCatch({
+    res <- force(statement)
+    call <- DBI::dbExecute(conn, "COMMIT")
+    if (identical(call, FALSE)) {
+      stop("Failed to commit transaction", call. = FALSE)
+    }
+    res
+  },
+  db_abort = rollback,
+  error = rollback,
+  interrupt = rollback
+  )
+}

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -90,9 +90,7 @@ test_that("query in sqlite works", {
   # depending on availability of regular expression operator
   expect_length(
     docdb_query(con, "mt-cars",
-                query = paste0('{"gear" : 4, "cyl": {"$lte": 8}, "_row": {"$regex": "',
-                               ifelse(attr(x = con$con, which = "regexp.extension"),
-                                      '^M[a-z].*', 'M%'), '"} }'),
+                query = '{"gear" : 4, "cyl": {"$lte": 8}, "_row": {"$regex": "^M[a-z].*"} }',
                 fields = '{"mpg":1, "cyl": 1, "_row": 1}')[["_id"]],
     6L)
 


### PR DESCRIPTION
Since RSQLite version 2.2.4 released on 2021-03-12, its concurrency behaviour can be set. This enables to addition transactions such as used in DBI. 

## Description
Functions `docdb_create`, `docdb_update` and `docdb_delete` were updated for `src_sqlite` connection objects to use a new function `dbWithTransaction` in analogy to how this is done in package `DBI`. 

## Example
No user-visible changes. 